### PR TITLE
fix: approveRequestにid範囲チェックを追加

### DIFF
--- a/extend_form/code.js
+++ b/extend_form/code.js
@@ -249,8 +249,8 @@ function approveRequest(id, newDate) {
   }
   // 申請者情報取得
   const data = SHEET.getDataRange().getValues();
-  // id の範囲チェック
-  if (typeof id !== "number" || id < 0 || id >= data.length) {
+  // id の範囲チェック (整数かつ 1 行目以降のみ有効)
+  if (!Number.isInteger(id) || id < 1 || id >= data.length) {
     Logger.log(`無効な id: ${id}`);
     return;
   }

--- a/extend_form/code.js
+++ b/extend_form/code.js
@@ -249,6 +249,11 @@ function approveRequest(id, newDate) {
   }
   // 申請者情報取得
   const data = SHEET.getDataRange().getValues();
+  // id の範囲チェック
+  if (typeof id !== "number" || id < 0 || id >= data.length) {
+    Logger.log(`無効な id: ${id}`);
+    return;
+  }
   Logger.log(`延長申請を許可: ${id} 行目、${newDate} まで`);
   SHEET.getRange(id + 1, HANDOVER_ON + 1).setValue(newDate);
   const email = data[id][EMAIL];


### PR DESCRIPTION
## 概要
Issue #65 に対応し、`approveRequest` に `id` の型・範囲チェックを追加しました。

## 変更内容
- `extend_form/code.js`
  - `approveRequest(id, newDate)` 内で `data` 取得後に `id` 妥当性を検証
  - 無効値の場合はログ出力して早期 `return`

## 影響
- 無効な `id` による誤更新/実行時エラーのリスクを低減
- 正常系の承認処理フローは維持

Closes #65
