### PR TITLE
fix: handoverDay判定の型揺れを吸収

### DIFF
--- a/line_bot/code.js
+++ b/line_bot/code.js
@@ -30,7 +30,7 @@ function handoverDayRemind() {
     const email = data[i][EMAIL];
     const name = data[i][NAME];
     const organ = data[i][ORGANIZATION];
-    const handoverDay = data[i][DAYS_UNTIL_HANDOVER];
+    const handoverDay = Number(data[i][DAYS_UNTIL_HANDOVER]);
 
     let mailFailLog = null; // メール送信失敗時のログ
 


### PR DESCRIPTION
## 概要
Issue #63 に対応し、`handoverDayRemind` の判定前に `handoverDay` を数値化しました。

## 変更内容
- `line_bot/code.js`
  - `const handoverDay = Number(data[i][DAYS_UNTIL_HANDOVER]);`

## 影響
- `3` / `"3"`、`0` / `"0"` の型差異に関わらず同一判定
- 型揺れによる通知漏れリスクを低減

Closes #63
