### PR TITLE
fix: doGetのXFrameOptionsMode依存を解消

### DIFF
--- a/extend_form/code.js
+++ b/extend_form/code.js
@@ -23,8 +23,7 @@ const DOMAIN = 'mail.ryukoku.ac.jp';
 // === HTMLフォーム表示 ===
 function doGet() {
   return HtmlService.createHtmlOutputFromFile("index")
-    .setTitle("延長申請フォーム")
-    .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
+    .setTitle("延長申請フォーム");
 }
 
 // function doGet() {


### PR DESCRIPTION
## 概要
Issue #64 に対応し、`doGet` の `XFrameOptionsMode.ALLOWALL` 依存を取り除きました。

## 変更内容
- `extend_form/code.js`
  - `doGet()` から `setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL)` を削除

## 影響
- 実行環境による `XFrameOptionsMode` 未定義エラーの回避
- 既存のページ表示フローは維持

Closes #64
