### PR TITLE
fix: 必須properties/シート存在の起動時バリデーションを追加

### DIFF
--- a/extend_form/code.js
+++ b/extend_form/code.js
@@ -15,7 +15,7 @@ const SHEET_NAME_MANAGE = getRequiredProperty('SHEET_NAME_MANAGE');
 const SPREAD_SHEET = SpreadsheetApp.openById(SPREAD_SHEET_ID);
 const SHEET = SPREAD_SHEET.getSheetByName(SHEET_NAME_MANAGE);
 if (!SHEET) {
-  throw new Error(`Sheet "${SHEET_NAME_MANAGE}" not found in spreadsheet.`);
+  throw new Error(`Sheet "${SHEET_NAME_MANAGE}" not found in spreadsheet. SPREAD_SHEET_ID="${SPREAD_SHEET_ID}", URL="https://docs.google.com/spreadsheets/d/${SPREAD_SHEET_ID}"`);
 }
 
 // 列要素

--- a/extend_form/code.js
+++ b/extend_form/code.js
@@ -1,11 +1,22 @@
 const scriptProperties = PropertiesService.getScriptProperties();
-const ACCESS_TOKEN = scriptProperties.getProperty('ACCESS_TOKEN');
-const USER_ID = scriptProperties.getProperty('USER_ID');
-const SPREAD_SHEET_ID = scriptProperties.getProperty('SPREAD_SHEET_ID');
-const SHEET_NAME_MANAGE = scriptProperties.getProperty('SHEET_NAME_MANAGE');
+function getRequiredProperty(key) {
+  const value = scriptProperties.getProperty(key);
+  if (!value) {
+    throw new Error(`${key} script property is not set.`);
+  }
+  return value;
+}
+
+const ACCESS_TOKEN = getRequiredProperty('ACCESS_TOKEN');
+const USER_ID = getRequiredProperty('USER_ID');
+const SPREAD_SHEET_ID = getRequiredProperty('SPREAD_SHEET_ID');
+const SHEET_NAME_MANAGE = getRequiredProperty('SHEET_NAME_MANAGE');
 
 const SPREAD_SHEET = SpreadsheetApp.openById(SPREAD_SHEET_ID);
 const SHEET = SPREAD_SHEET.getSheetByName(SHEET_NAME_MANAGE);
+if (!SHEET) {
+  throw new Error(`Sheet "${SHEET_NAME_MANAGE}" not found in spreadsheet.`);
+}
 
 // 列要素
 const RESISTERED_AT = 0;        // フォーム送信時刻（自動記録）

--- a/extend_form/code.js
+++ b/extend_form/code.js
@@ -2,7 +2,7 @@ const scriptProperties = PropertiesService.getScriptProperties();
 function getRequiredProperty(key) {
   const value = scriptProperties.getProperty(key);
   if (!value) {
-    throw new Error(`${key} script property is not set.`);
+    throw new Error(`${key} Script Property is not set. Configure it in Apps Script: Project Settings > Script Properties.`);
   }
   return value;
 }

--- a/line_bot/code.js
+++ b/line_bot/code.js
@@ -1,7 +1,7 @@
 const scriptProperties = PropertiesService.getScriptProperties();
 function getRequiredProperty(key) {
   const value = scriptProperties.getProperty(key);
-  if (!value) {
+  if (value === null || value === '') {
     throw new Error(`${key} script property is not set. Please set it in Project Settings > Script Properties.`);
   }
   return value;

--- a/line_bot/code.js
+++ b/line_bot/code.js
@@ -1,12 +1,23 @@
 const scriptProperties = PropertiesService.getScriptProperties();
-const ACCESS_TOKEN = scriptProperties.getProperty('ACCESS_TOKEN');
-const USER_ID = scriptProperties.getProperty('USER_ID');
-const FORM_URL = scriptProperties.getProperty('FORM_URL');
-const SPREAD_SHEET_ID = scriptProperties.getProperty('SPREAD_SHEET_ID');
-const SHEET_NAME_MANAGE = scriptProperties.getProperty('SHEET_NAME_MANAGE');
+function getRequiredProperty(key) {
+  const value = scriptProperties.getProperty(key);
+  if (!value) {
+    throw new Error(`${key} script property is not set.`);
+  }
+  return value;
+}
+
+const ACCESS_TOKEN = getRequiredProperty('ACCESS_TOKEN');
+const USER_ID = getRequiredProperty('USER_ID');
+const FORM_URL = getRequiredProperty('FORM_URL');
+const SPREAD_SHEET_ID = getRequiredProperty('SPREAD_SHEET_ID');
+const SHEET_NAME_MANAGE = getRequiredProperty('SHEET_NAME_MANAGE');
 
 const SPREAD_SHEET = SpreadsheetApp.openById(SPREAD_SHEET_ID);
 const SHEET = SPREAD_SHEET.getSheetByName(SHEET_NAME_MANAGE);
+if (!SHEET) {
+  throw new Error(`Sheet "${SHEET_NAME_MANAGE}" not found in spreadsheet.`);
+}
 
 // 列要素
 const REGISTERED_AT = 0;        // フォーム送信時刻（自動記録）

--- a/line_bot/code.js
+++ b/line_bot/code.js
@@ -16,7 +16,7 @@ const SHEET_NAME_MANAGE = getRequiredProperty('SHEET_NAME_MANAGE');
 const SPREAD_SHEET = SpreadsheetApp.openById(SPREAD_SHEET_ID);
 const SHEET = SPREAD_SHEET.getSheetByName(SHEET_NAME_MANAGE);
 if (!SHEET) {
-  throw new Error(`Sheet "${SHEET_NAME_MANAGE}" not found in spreadsheet.`);
+  throw new Error(`Sheet "${SHEET_NAME_MANAGE}" not found in spreadsheet with ID "${SPREAD_SHEET_ID}". URL: https://docs.google.com/spreadsheets/d/${SPREAD_SHEET_ID}`);
 }
 
 // 列要素

--- a/line_bot/code.js
+++ b/line_bot/code.js
@@ -2,7 +2,7 @@ const scriptProperties = PropertiesService.getScriptProperties();
 function getRequiredProperty(key) {
   const value = scriptProperties.getProperty(key);
   if (!value) {
-    throw new Error(`${key} script property is not set.`);
+    throw new Error(`${key} script property is not set. Please set it in Project Settings > Script Properties.`);
   }
   return value;
 }


### PR DESCRIPTION
## 概要
Issue #72 に対応し、`extend_form` と `line_bot` で必須 Script Properties と参照シートの存在を起動時に検証するようにしました。

## 変更内容
- `extend_form/code.js`
  - `getRequiredProperty(key)` を追加
  - `ACCESS_TOKEN`, `USER_ID`, `SPREAD_SHEET_ID`, `SHEET_NAME_MANAGE` を必須化
  - `getSheetByName` 結果が `null` の場合に明確なエラーを throw
- `line_bot/code.js`
  - `getRequiredProperty(key)` を追加
  - `ACCESS_TOKEN`, `USER_ID`, `FORM_URL`, `SPREAD_SHEET_ID`, `SHEET_NAME_MANAGE` を必須化
  - `getSheetByName` 結果が `null` の場合に明確なエラーを throw

## 影響
- 設定不足時に、実行時の不明瞭な失敗ではなく原因が明確なエラーで停止
- 正常設定時の既存機能フローは維持

Closes #72
